### PR TITLE
BDOG-2378 Add NONCE_ATTR placeholder

### DIFF
--- a/app/views/HMRCEmbeddedView.scala.html
+++ b/app/views/HMRCEmbeddedView.scala.html
@@ -15,12 +15,11 @@
  *@
 
 @import config.AppConfig
-@import views.html.helper.CSPNonce
 
 @this(appConfig: AppConfig)
 
 @()(implicit request: Request[_])
 
-<script @{CSPNonce.attr} language="javascript" id="hmrc-webchat-tag" src=@{appConfig.hmrcSkinJSUrl}></script>
-<link @{CSPNonce.attr} rel="stylesheet" href='@{appConfig.hmrcSkinEmbeddedCSSUrl}' type="text/css">
+<script {{NONCE_ATTR}} language="javascript" id="hmrc-webchat-tag" src=@{appConfig.hmrcSkinJSUrl}></script>
+<link {{NONCE_ATTR}} rel="stylesheet" href='@{appConfig.hmrcSkinEmbeddedCSSUrl}' type="text/css">
 <div class="dav3"></div>

--- a/app/views/HMRCPopupView.scala.html
+++ b/app/views/HMRCPopupView.scala.html
@@ -15,11 +15,10 @@
  *@
 
 @import config.AppConfig
-@import views.html.helper.CSPNonce
 
 @this(appConfig: AppConfig)
 
 @()(implicit request: Request[_])
 
-<script @{CSPNonce.attr} language="javascript" id="hmrc-webchat-tag" src=@{appConfig.hmrcSkinJSUrl}></script>
-<link @{CSPNonce.attr} rel="stylesheet" href='@{appConfig.hmrcSkinPopupCSSUrl}' type="text/css">
+<script {{NONCE_ATTR}} language="javascript" id="hmrc-webchat-tag" src=@{appConfig.hmrcSkinJSUrl}></script>
+<link {{NONCE_ATTR}} rel="stylesheet" href='@{appConfig.hmrcSkinPopupCSSUrl}' type="text/css">

--- a/app/views/NuanceView.scala.html
+++ b/app/views/NuanceView.scala.html
@@ -21,7 +21,7 @@
 
 @(nuanceData: EncryptedNuanceData)
 
-<script>
+<script {{NONCE_ATTR}}>
     var nuanceData = {
         "mdtpdfSessionID" : "@{nuanceData.nuanceSessionId}",
         "mdtpSessionID" : "@{nuanceData.mdtpSessionId}",
@@ -29,4 +29,4 @@
     }
 </script>
 
-<script id="webchat-tag" src=@{appConfig.nuanceUrl}></script>
+<script {{NONCE_ATTR}} id="webchat-tag" src=@{appConfig.nuanceUrl}></script>


### PR DESCRIPTION
# BDOG-2378
This change supports the enablement of nonce CSP.

The current use of `@{CSPNonce.attr}` did not do anything since the `play.filters.csp..CSPFilter` has not been enabled. And if it were enabled, it would be a different nonce from the client, so would not have worked.

The nonce will be provided by the client of the partial, so here we have just added a placeholder for the client to replace.
This will still work for clients who don't replace the placeholder, leading to a placeholder the browser will  ignore.

## Checklist PR Raiser
 - [ ]  I've ensured code coverage has not decreased
 - [ ]  I've dealt with any new compilation warnings
 - [ ]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [ ]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [ ]  I've checked to ensure all relevant unit tests have been written
 - [ ]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  If I merge I will ensure I use squash and merge